### PR TITLE
링크 수정

### DIFF
--- a/docs/util_docs.md
+++ b/docs/util_docs.md
@@ -7,4 +7,4 @@
 - 실행 >> 해당 폴더 안에서 아래 명령어 실행
 `$> client_merge.sh`
 - 만약 remote origin 의 경로를 변경할 일이 있다면 코드의 A1 - 이 붙은 코드를 제거
-
+- source code : <a href='../utils/client_merge.sh'>client_merge.sh</a>


### PR DESCRIPTION
Utility 링크 수정 
sh 에 대해 이전에 몰랐던 점 >>
- 사용시 `./filename.sh` 로 사용했었는데, 일반적인 사용은 `sh filename` 이다.
- 예를 들어, 리눅스 시스템의 ulimit 을 호출한다면 sh ulimit 로 호출해야 함.(이건 좀 다른 이야기일지도...)